### PR TITLE
Update go client to interop version 6 and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Apple published an example implementation of a resumable upload server built usi
 
 ### Tusdotnet (.NET)
 
-[Tusdotnet](https://tus.github.io/tusd/) is a feature-rich .NET server implementation of the [tus resumable upload protocol](https://tus.io), which also includes experimental support for the draft of Resumable Upload For HTTP. Details on how to use tusdotnet with the draft can be found at https://github.com/tusdotnet/tusdotnet/tree/POC/tus2.
+[Tusdotnet](https://github.com/tusdotnet/tusdotnet/) is a feature-rich .NET server implementation of the [tus resumable upload protocol](https://tus.io), which also includes experimental support for the draft of Resumable Upload For HTTP. Details on how to use tusdotnet with the draft can be found at https://github.com/tusdotnet/tusdotnet/tree/POC/tus2.
 
 ### Go server example
 
@@ -56,22 +56,22 @@ The draft is currently still in a developing state, where it is actively discuss
 
 The following table provides an overview of which draft version is supported by which client or server implementation. A client or server can support multiple versions by adjusting to the request of the user or client. If you want to pair a client with a server for uploading data, please ensure that both implement at least one shared draft version.
 
-| Draft version     | [-01](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-01) | [-02](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-02) | [-03](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-03) |
-|:------------------|----|----|----|
-| Interop version   | 3  | 4  | 5  |
-| **Clients**       |    |    |    |
-| URLSession on iOS | ✅ |    |    |
-| tus-js-client     |    |    |    |
-| Go example        | ✅ |    |    |
-| **Servers**       |    |    |    |
-| tusd              | ✅ | ✅ | ✅ |
-| tusdotnet         |    |    | ✅ |
-| SwiftNIO          | ✅ |    |    |
-| Go example        | ✅ |    |    |
-| Caddy module      |    | ✅ |    |
-| **Tools**         |    |    |    |
-| Conformity tester |    | ✅ |    |
-| Load tester       |    |    | ✅ |
+| Draft version     | [-01](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-01) | [-02](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-02) | [-03](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-03) |[-04](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-04)|
+|:------------------|----|----|----|----|
+| Interop version   | 3  | 4  | 5  | 6  |
+| **Clients**       |    |    |    |    |
+| URLSession on iOS | ✅ |    |    |    |
+| tus-js-client     |    |    |    |    |
+| Go example        | ✅ |    |    |    |
+| **Servers**       |    |    |    |    |
+| tusd              | ✅ | ✅ | ✅ |    |
+| tusdotnet         | ✅ |    | ✅ |✅  |
+| SwiftNIO          | ✅ |    |    |    |
+| Go example        | ✅ |    |    |    |
+| Caddy module      |    | ✅ |    |    |
+| **Tools**         |    |    |    |    |
+| Conformity tester |    | ✅ |    |    |
+| Load tester       |    |    | ✅ |    |
 
 
 ## Interoperability

--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-const InteropVersion = "5"
+const InteropVersion = "6"
 
 var endpoint string
 var filepath string
@@ -123,8 +123,9 @@ func uploadCreationProcedure(file *os.File) (string, error) {
 			}
 
 			uploadUrl := header.Get("Location")
+			uploadLimit := header.Get("Upload-Limit")
 			if uploadUrl != "" {
-				log.Printf("Received 104 response. Location is: %s\n", uploadUrl)
+				log.Printf("Received 104 response.\nLocation is: %s\nUpload-Limit is: %s\n", uploadUrl, uploadLimit)
 
 				if err := saveUploadState(uploadUrl); err != nil {
 					log.Printf("failed to write upload state file: %s", err)
@@ -193,6 +194,7 @@ func uploadAppendingProcedure(uploadUrl string, file *os.File, offset int64) (st
 	req.Header.Set("Upload-Draft-Interop-Version", InteropVersion)
 	req.Header.Set("Upload-Offset", strconv.FormatInt(offset, 10))
 	req.Header.Set("Upload-Complete", "?1")
+	req.Header.Set("Content-Type", "application/partial-upload")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
What the title says. I'm not sure on how to modify the tus-js-client to interop version 6 as it's pushed to unpkg.